### PR TITLE
Set pts at the end of stream (opus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `membrane_opus_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_opus_plugin, "~> 0.20.0"}
+    {:membrane_opus_plugin, "~> 0.20.1"}
   ]
 end
 ```

--- a/lib/membrane_opus/encoder.ex
+++ b/lib/membrane_opus/encoder.ex
@@ -165,7 +165,7 @@ defmodule Membrane.Opus.Encoder do
       # pad with 0
       to_encode = String.pad_trailing(state.queue, frame_size_in_bytes(state), <<0>>)
       {:ok, raw_encoded} = Native.encode_packet(state.native, to_encode, frame_size(state))
-      buffer_actions = [buffer: {:output, %Buffer{payload: raw_encoded}}]
+      buffer_actions = [buffer: {:output, %Buffer{payload: raw_encoded, pts: state.current_pts}}]
       {buffer_actions ++ actions, %{state | queue: <<>>}}
     else
       {actions, %{state | queue: <<>>}}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Opus.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.20.0"
+  @version "0.20.1"
   @github_url "https://github.com/membraneframework/membrane_opus_plugin"
 
   def project do


### PR DESCRIPTION
PTS value is bumped every time encode_buffer is run.
After last encode_buffer in state there is a PTS value ready for the next buffer, that means we simply assign pts from state to the buffer that's returned from end_of_stream.